### PR TITLE
feat: full rss feed for blog

### DIFF
--- a/themes/delphi/layouts/blog/rss.xml
+++ b/themes/delphi/layouts/blog/rss.xml
@@ -1,0 +1,62 @@
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" -}}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end -}}
+    {{ range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ if .Params.author }}
+        <author>{{ .Params.author }}</author>
+      {{ else }}
+        {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>
+    {{- $html := htmlUnescape .Content | safeHTML -}}
+    {{- $srcs := findRE "src=\"([^\"]*)\"" $html -}}
+    {{/* replace links with absolute links */}}
+    {{- range $src := $srcs -}}
+      {{- $absSrc := strings.TrimPrefix "src=\"" $src -}}
+      {{- $absSrc = strings.TrimSuffix "\"" $absSrc  -}}
+      {{- $absSrc = printf "src=\"%s\"" ($absSrc | absURL) -}}
+      {{- $html = replace $html $src $absSrc -}}
+    {{- end }}
+    {{- $srcs := findRE "href=\"([^\"]*)\"" $html -}}
+    {{/* replace links with absolute links */}}
+    {{- range $src := $srcs -}}
+      {{- $absSrc := strings.TrimPrefix "href=\"" $src -}}
+      {{- $absSrc = strings.TrimSuffix "\"" $absSrc  -}}
+      {{- $absSrc = printf "href=\"%s\"" ($absSrc | absURL) -}}
+      {{- $html = replace $html $src $absSrc -}}
+    {{- end }}
+    {{- htmlEscape $html -}}
+      </description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
re implementation of https://github.com/cmu-delphi/delphi-blog/pull/28

once deployed: .../blog/index.xml will contained the escaped full blog post