### PR TITLE
Fix emphasis color.

### DIFF
--- a/themes/delphi/assets/css/_customize.scss
+++ b/themes/delphi/assets/css/_customize.scss
@@ -2,6 +2,8 @@
 // Font
 $global-font-family: "Open Sans", Roboto, Arial, sans-serif;
 
+$base-em-color: $global-color;
+
 // Breakpoints:
 $breakpoint-small: 715px;
 $breakpoint-medium: 1000px;

--- a/themes/delphi/assets/css/_customize.scss
+++ b/themes/delphi/assets/css/_customize.scss
@@ -1,7 +1,7 @@
-
 // Font
 $global-font-family: "Open Sans", Roboto, Arial, sans-serif;
 
+$global-color: #666;
 $base-em-color: $global-color;
 
 // Breakpoints:

--- a/themes/delphi/assets/css/pages/_landing.scss
+++ b/themes/delphi/assets/css/pages/_landing.scss
@@ -1,4 +1,3 @@
-
 //The UIKit slideshow component doesn't want to stay inside its parent container
 //We have to do multiple things to keep it in check:
 //

--- a/themes/delphi/assets/css/pages/_landing.scss
+++ b/themes/delphi/assets/css/pages/_landing.scss
@@ -82,7 +82,7 @@ $carousel-height:500px;
         font-size: 32px;
     }
     a {
-        color: #666;
+        color: $global-color;
         font-weight: bold;
     }
 }


### PR DESCRIPTION
UIkit has an odd default color for `em` tags that makes them the `warning` color, which is a super weird semantic decision to make.

Update to use the global font color.