### PR TITLE
feat: use latest dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1596,7 +1596,7 @@
    "dev": true
   },
   "www-covidcast": {
-   "version": "github:cmu-delphi/www-covidcast#3daf340b9fa176dda6172fd204634801f0254381",
+   "version": "github:cmu-delphi/www-covidcast#764f20b16e532cf18e051c2499e92cad240413ce",
    "from": "github:cmu-delphi/www-covidcast#dev",
    "requires": {
     "uikit": "^3.5.9"


### PR DESCRIPTION
use the latest covidcast dev version, since for reproducibility reason, the package-lock.json will refer to a specific commit.