### PR TITLE
build: prettier ignore (R)markdown

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,5 @@
 *.woff2
 *.R
 *.xml
+*.Rmd
+*.md

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -10,11 +10,5 @@ module.exports = {
         parser: "go-template",
       },
     },
-    {
-      files: ["*.Rmd"],
-      options: {
-        parser: "markdown",
-      },
-    },
   ],
 };


### PR DESCRIPTION
closes #143

which should simplify the editing of Markdown files for content editors. Markdown is pretty relaxed when it comes to formatting and white spaces, to not enforcing a specific format shouldn't do much harm.

