### PR TITLE
add uikit icons

### DIFF
--- a/themes/delphi/assets/js/main.js
+++ b/themes/delphi/assets/js/main.js
@@ -1,6 +1,6 @@
 import UIkit from "uikit/dist/js/uikit.js";
-// import plugin from 'uikit/dist/js/uikit-icons.js';
-// UIkit.use(plugin);
+import plugin from 'uikit/dist/js/uikit-icons.js';
+UIkit.use(plugin);
 
 // re export for COVIDCast
 window.UIkit = UIkit;

--- a/themes/delphi/assets/js/main.js
+++ b/themes/delphi/assets/js/main.js
@@ -1,5 +1,5 @@
 import UIkit from "uikit/dist/js/uikit.js";
-import plugin from 'uikit/dist/js/uikit-icons.js';
+import plugin from "uikit/dist/js/uikit-icons.js";
 UIkit.use(plugin);
 
 // re export for COVIDCast


### PR DESCRIPTION
enables/includes the UIKit icons since they are now used by the migrated covidcast. (Fontawesome wasn't used yet, when I migrated covidcast to uikit)