### PR TITLE
feat: add social media tags

### DIFF
--- a/content/covidcast/_index.md
+++ b/content/covidcast/_index.md
@@ -1,4 +1,5 @@
 ---
-title: COVIDCast
+title: COVIDcast
 layout: covidcast_app
+description: COVIDcast tracks and forecasts the spread of COVID-19. By Carnegie Mellon's Delphi Research Group.
 ---

--- a/data/authors.yaml
+++ b/data/authors.yaml
@@ -17,6 +17,7 @@
   name: Alex Reinhart
   link: https://www.refsmmat.com
   description: manages Delphi's surveys, and is an Assistant Teaching Professor in the Department of Statistics & Data Science at CMU.
+  twitter: capnrefsmmat
 - key: kathryn
   name: Kathryn Mazaitis
   link: https://cs.cmu.edu/~krivard

--- a/themes/delphi/layouts/partials/head/meta.html
+++ b/themes/delphi/layouts/partials/head/meta.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="format-detection" content="telephone=no" />
 
-{{partial "head/socialmedia.html" .}}
+{{ partial "head/socialmedia.html" . }}
 
 <!-- Icons -->
 <link rel="apple-touch-icon" sizes="180x180" href="{{ "apple-touch-icon.png" | relURL }}" />

--- a/themes/delphi/layouts/partials/head/meta.html
+++ b/themes/delphi/layouts/partials/head/meta.html
@@ -3,7 +3,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="format-detection" content="telephone=no" />
 
-<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
+{{partial "head/socialmedia.html" .}}
+
 <!-- Icons -->
 <link rel="apple-touch-icon" sizes="180x180" href="{{ "apple-touch-icon.png" | relURL }}" />
 <link rel="icon" type="image/png" sizes="32x32" href="{{ "favicon-32x32.png" | relURL }}" />

--- a/themes/delphi/layouts/partials/head/socialmedia.html
+++ b/themes/delphi/layouts/partials/head/socialmedia.html
@@ -50,18 +50,15 @@
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
 {{- if .IsPage }}
   {{- if not .PublishDate.IsZero }}
-    <meta property="article:published_time" {{ .PublishDate.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-    {{ else if not .Date.IsZero }}<meta
-      property="article:published_time"
-      {{ .Date.Format $iso8601 | printf "content=%q" | safeHTMLAttr }}
-    />
+    <meta property="article:published_time" content="{{ .PublishDate.Format $iso8601 }}" />
+    {{ else if not .Date.IsZero }}<meta property="article:published_time" content="{{ .Date.Format $iso8601 }}" />
   {{ end }}
   {{- if not .Lastmod.IsZero }}
-    <meta property="article:modified_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }}
+    <meta property="article:modified_time" content="{{ .Lastmod.Format $iso8601 }}"
   />{{ end }}
   {{- else }}
   {{- if not .Date.IsZero }}
-    <meta property="og:updated_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
+    <meta property="og:updated_time" content="{{ .Date.Format $iso8601 }}" />
   {{- end }}
 {{- end }}
 

--- a/themes/delphi/layouts/partials/head/socialmedia.html
+++ b/themes/delphi/layouts/partials/head/socialmedia.html
@@ -1,0 +1,52 @@
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
+<meta name="twitter:title" content="{{ .Title }}"/>
+<meta property="og:title" content="{{ .Title }}" />
+
+<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
+<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
+<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}" />
+
+<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
+
+{{- with .Params.tags -}}
+<meta name="keywords" content="{{ delimit . ", " }}" />
+{{- range . -}}
+    <meta property="article:tag" content="{{ . }}" />
+{{- end -}}
+{{- end -}}
+
+<meta name="author" content="Delphi Group">
+<meta name="twitter:site" content="@{{ .Site.Params.twitter }}"/>
+
+{{- with .Params.authors -}}
+{{- range . -}}
+    {{- range first 1 (where $.Site.Data.authors "key" "eq" .) -}}
+        {{- if isset . "twitter" -}}
+        <meta name="twitter:creator" content="@{{ .twitter }}"/>
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- with .Params.heroImage -}}
+<meta name="twitter:image" content="{{ . | absURL }}" />
+<meta property="og:image" content="{{ . | absURL }}" />
+<meta name="twitter:card" content="summary_large_image"/>
+{{- else -}}
+<meta name="twitter:card" content="summary"/>
+{{- end -}}
+
+{{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
+{{- if .IsPage }}
+{{- if not .PublishDate.IsZero }}<meta property="article:published_time" {{ .PublishDate.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
+{{ else if not .Date.IsZero }}<meta property="article:published_time" {{ .Date.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
+{{ end }}
+{{- if not .Lastmod.IsZero }}<meta property="article:modified_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
+{{- else }}
+{{- if not .Date.IsZero }}<meta property="og:updated_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
+{{- end }}
+{{- end }}
+
+{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
+{{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}

--- a/themes/delphi/layouts/partials/head/socialmedia.html
+++ b/themes/delphi/layouts/partials/head/socialmedia.html
@@ -1,51 +1,67 @@
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
-<meta name="twitter:title" content="{{ .Title }}"/>
+<meta name="twitter:title" content="{{ .Title }}" />
 <meta property="og:title" content="{{ .Title }}" />
 
-<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
-<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
-<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}" />
+<meta
+  name="description"
+  content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"
+/>
+<meta
+  name="twitter:description"
+  content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"
+/>
+<meta
+  property="og:description"
+  content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"
+/>
 
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 
 {{- with .Params.tags -}}
-<meta name="keywords" content="{{ delimit . ", " }}" />
-{{- range . -}}
+  <meta name="keywords" content="{{ delimit . ", " }}" />
+  {{- range . -}}
     <meta property="article:tag" content="{{ . }}" />
-{{- end -}}
+  {{- end -}}
 {{- end -}}
 
-<meta name="author" content="Delphi Group">
-<meta name="twitter:site" content="@{{ .Site.Params.twitter }}"/>
+<meta name="author" content="Delphi Group" />
+<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
 
 {{- with .Params.authors -}}
-{{- range . -}}
+  {{- range . -}}
     {{- range first 1 (where $.Site.Data.authors "key" "eq" .) -}}
-        {{- if isset . "twitter" -}}
-        <meta name="twitter:creator" content="@{{ .twitter }}"/>
-        {{- end -}}
+      {{- if isset . "twitter" -}}
+        <meta name="twitter:creator" content="@{{ .twitter }}" />
+      {{- end -}}
     {{- end -}}
-{{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{- with .Params.heroImage -}}
-<meta name="twitter:image" content="{{ . | absURL }}" />
-<meta property="og:image" content="{{ . | absURL }}" />
-<meta name="twitter:card" content="summary_large_image"/>
-{{- else -}}
-<meta name="twitter:card" content="summary"/>
+  <meta name="twitter:image" content="{{ . | absURL }}" />
+  <meta property="og:image" content="{{ . | absURL }}" />
+  <meta name="twitter:card" content="summary_large_image" />
+  {{- else -}}
+  <meta name="twitter:card" content="summary" />
 {{- end -}}
 
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
 {{- if .IsPage }}
-{{- if not .PublishDate.IsZero }}<meta property="article:published_time" {{ .PublishDate.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-{{ else if not .Date.IsZero }}<meta property="article:published_time" {{ .Date.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-{{ end }}
-{{- if not .Lastmod.IsZero }}<meta property="article:modified_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
-{{- else }}
-{{- if not .Date.IsZero }}<meta property="og:updated_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-{{- end }}
+  {{- if not .PublishDate.IsZero }}
+    <meta property="article:published_time" {{ .PublishDate.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
+    {{ else if not .Date.IsZero }}<meta
+      property="article:published_time"
+      {{ .Date.Format $iso8601 | printf "content=%q" | safeHTMLAttr }}
+    />
+  {{ end }}
+  {{- if not .Lastmod.IsZero }}
+    <meta property="article:modified_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }}
+  />{{ end }}
+  {{- else }}
+  {{- if not .Date.IsZero }}
+    <meta property="og:updated_time" {{ .Lastmod.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
+  {{- end }}
 {{- end }}
 
 {{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}

--- a/themes/delphi/layouts/partials/head/socialmedia.html
+++ b/themes/delphi/layouts/partials/head/socialmedia.html
@@ -17,6 +17,7 @@
 
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
+<meta property="twitter:url" content="{{ .Permalink }}" />
 
 {{- with .Params.tags -}}
   <meta name="keywords" content="{{ delimit . ", " }}" />
@@ -50,9 +51,7 @@
 {{- if .IsPage }}
   {{- if not .PublishDate.IsZero }}
     <meta property="article:published_time" {{ .PublishDate.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-    {{ else if not .Date.IsZero }}<meta
-      property="article:published_time"
-      {{ .Date.Format $iso8601 | printf "content=%q" | safeHTMLAttr }}
+    {{ else if not .Date.IsZero }}<meta property="article:published_time" <!--BPGTBPGT323EPGTEPGT-- />
     />
   {{ end }}
   {{- if not .Lastmod.IsZero }}

--- a/themes/delphi/layouts/partials/head/socialmedia.html
+++ b/themes/delphi/layouts/partials/head/socialmedia.html
@@ -51,7 +51,9 @@
 {{- if .IsPage }}
   {{- if not .PublishDate.IsZero }}
     <meta property="article:published_time" {{ .PublishDate.Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
-    {{ else if not .Date.IsZero }}<meta property="article:published_time" <!--BPGTBPGT323EPGTEPGT-- />
+    {{ else if not .Date.IsZero }}<meta
+      property="article:published_time"
+      {{ .Date.Format $iso8601 | printf "content=%q" | safeHTMLAttr }}
     />
   {{ end }}
   {{- if not .Lastmod.IsZero }}


### PR DESCRIPTION
closes #184 

sets generic social media tags (based on internal hugo templates) for twitter and OpenGraph = facebook and co. Images for now are just for blog posts.

using https://metatags.io:

main: 
![image](https://user-images.githubusercontent.com/4129778/102782570-94148f80-4367-11eb-8695-77be7e3a5863.png)

blog:

![image](https://user-images.githubusercontent.com/4129778/102782541-85c67380-4367-11eb-9936-51c8c36f1df1.png)

slack previews:

![image](https://user-images.githubusercontent.com/4129778/102782724-d0e08680-4367-11eb-95fd-055e96e11c75.png)
