### PR TITLE
style: fix for ios wrapped height

### DIFF
--- a/themes/delphi/assets/css/pages/_covidcast.scss
+++ b/themes/delphi/assets/css/pages/_covidcast.scss
@@ -5,7 +5,7 @@
 .covidcast_wrapper {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  min-height: 100vh;
 }
 
 .covidcast_wrapper:not(.covidcast_wrapper_footer) > footer {


### PR DESCRIPTION
on iPhone11 the view looks packed to the height with overlapping content and footer. This should fix it