### PR TITLE
update to COVIDcast v2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2606,8 +2606,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.3.0/www-covidcast-2.3.0.tgz",
-      "integrity": "sha512-6f9xFOOMtmudqv4oQlvj7YRB/EjBPev/5+GyGFCx+ldQj1XVDqM7n4TLyZNUhER5YGRJTsxGEqTh12a+0u7PaQ==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.3.1/www-covidcast-2.3.1.tgz",
+      "integrity": "sha512-HmbZR5AJBus205Y7wnVkd5JkVFZumyOqouzWx8GaaH3Nr7+Tkk1ec+96FJOIqgY6KUFgFcOe+66A6jnnQXZodg==",
       "requires": {
         "uikit": "^3.6.18"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^10.6.0",
     "katex": "^0.13.0",
     "uikit": "^3.6.18",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.3.0/www-covidcast-2.3.0.tgz"
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.3.1/www-covidcast-2.3.1.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.69.0",


### PR DESCRIPTION
update to [COVIDcast v2.3.1](https://github.com/cmu-delphi/www-covidcast/releases/v2.3.1)