### PR TITLE
build: tune blog down generation

### DIFF
--- a/.github/workflows/blog.yaml
+++ b/.github/workflows/blog.yaml
@@ -47,9 +47,8 @@ jobs:
         with:
           path: |
             ./blogdown
-          key: ${{ runner.os }}-blogdown2-${{ hashFiles('environment.yml') }}-${{ hashFiles('content/blog/**.Rmd') }}
+          key: ${{ runner.os }}-blogdown2-${{ hashFiles('environment.yml') }}
           restore-keys: |
-            ${{ runner.os }}-blogdown2-${{ hashFiles('environment.yml') }}-
             ${{ runner.os }}-blogdown2-
       - name: Build site
         shell: bash -l {0}

--- a/.github/workflows/blog.yaml
+++ b/.github/workflows/blog.yaml
@@ -5,10 +5,11 @@ on:
     paths: # run only when an Rmd file changes
       - "**.Rmd"
       - "environment.yml"
+      - "dependencies.R"
       - ".github/workflows/blog.yaml"
 
 jobs:
-  build:
+  build_blog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "copy_fonts": "shx cp -r \"node_modules/katex/dist/fonts/*\" themes/delphi/static/css/fonts/",
     "copy_covidcast": "shx rm -rf \"static/covidcast/*\" && shx cp \"node_modules/www-covidcast/public/**/*.{js,txt,css,map}\" static/covidcast/",
     "postinstall": "npm run copy_fonts && npm run copy_covidcast",
-    "build:blog": "Rscript -e \"blogdown::build_site(local=FALSE, run_hugo=FALSE, build_rmd='md5sum')\"",
+    "build:blog": "Rscript -e \"blogdown::build_site(local=FALSE, run_hugo=FALSE, build_rmd='timestamp')\"",
     "prebuild": "npm run clean",
     "build": "hugo --gc --minify",
     "start": "hugo server -D",


### PR DESCRIPTION
use the `timestamp` approach to avoid building everything in case there is no cache hit