### PR TITLE
update to EPIVis v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2566,8 +2566,8 @@
       }
     },
     "www-epivis": {
-      "version": "github:cmu-delphi/www-epivis#89ce44bfd7eb1bfeef0da64efdcf652793bef5c8",
-      "from": "github:cmu-delphi/www-epivis#dev",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.0/www-epivis-2.0.0.tgz",
+      "integrity": "sha512-3jhsaZ8TI0A9XPbdV9wd7TDiA2P+7Tf/53VX1ulmJlHuUhFVGMDVq4V5dJNxosw6PMvn5ClxY05BWLFTSx+0fg==",
       "requires": {
         "uikit": "^3.6.22"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "katex": "^0.13.11",
     "uikit": "^3.6.22",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.4.0/www-covidcast-2.4.0.tgz",
-    "www-epivis": "github:cmu-delphi/www-epivis#dev"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.0/www-epivis-2.0.0.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.71.1",


### PR DESCRIPTION
update to [EPIVis v2.0.0](https://github.com/cmu-delphi/www-epivis/releases/v2.0.0)