### PR TITLE
update to COVIDcast v2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2559,10 +2559,10 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.4.0/www-covidcast-2.4.0.tgz",
-      "integrity": "sha512-Uib4l9hzzuUw0++hR/JFHmWXAREy686cIhgZ+37EfL+q08OQHgAMkKSZjnk08M7kr2E2q+8xbgP3+R0gg45eYg==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.0/www-covidcast-2.5.0.tgz",
+      "integrity": "sha512-xQ5KNzbwvL+9q0enNJNJhiaCCTg0qUztIYNs2cEyoVGBrNwt93BNRiyv1e44HIS5qjXvcBh3qTTvZWABj8qocQ==",
       "requires": {
-        "uikit": "^3.6.19"
+        "uikit": "^3.6.22"
       }
     },
     "www-epivis": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.0.1",
     "katex": "^0.13.11",
     "uikit": "^3.6.22",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.4.0/www-covidcast-2.4.0.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.0/www-covidcast-2.5.0.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.0/www-epivis-2.0.0.tgz"
   },
   "devDependencies": {


### PR DESCRIPTION
update to [COVIDcast v2.5.0](https://github.com/cmu-delphi/www-covidcast/releases/v2.5.0)