### PR TITLE
update to COVIDcast v2.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2559,8 +2559,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.1/www-covidcast-2.5.1.tgz",
-      "integrity": "sha512-D4uVhQwFbsOLZPQ1s1v7/NB8ulyFZMCZVsyB1tISAX/35v4dCLSCb/2mwfJKbr1uWvOM/bkDv5Id48uNHy6F7g==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.2/www-covidcast-2.5.2.tgz",
+      "integrity": "sha512-AgWueUWfWuND8mbVOLdyqhft/tV9c7LeKq9PJA/DeNZNKp7azDYjmMMqh0IgzcilOlm5fqB4ecJ1OGOeHTruXQ==",
       "requires": {
         "uikit": "^3.6.22"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.0.1",
     "katex": "^0.13.11",
     "uikit": "^3.6.22",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.1/www-covidcast-2.5.1.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.2/www-covidcast-2.5.2.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },
   "devDependencies": {


### PR DESCRIPTION
update to [COVIDcast v2.5.2](https://github.com/cmu-delphi/www-covidcast/releases/v2.5.2)