### PR TITLE
update to COVIDcast v2.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2568,10 +2568,10 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.2/www-covidcast-2.5.2.tgz",
-      "integrity": "sha512-AgWueUWfWuND8mbVOLdyqhft/tV9c7LeKq9PJA/DeNZNKp7azDYjmMMqh0IgzcilOlm5fqB4ecJ1OGOeHTruXQ==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.3/www-covidcast-2.5.3.tgz",
+      "integrity": "sha512-TxiapT12gAgSjogiEUfR+Eivtr1MWRI9iIAtK6mVWRRN2RFu8d8OjQwx+kg9Oqpl8+ETcECjOT/2qMQN3wJawA==",
       "requires": {
-        "uikit": "^3.6.22"
+        "uikit": "^3.7.0"
       }
     },
     "www-covidcast-classic": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "highlight.js": "^11.0.1",
     "katex": "^0.13.11",
     "uikit": "^3.7.0",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.2/www-covidcast-2.5.2.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz",
-    "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.5.3/www-covidcast-classic-2.5.3.tgz"
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.3/www-covidcast-2.5.3.tgz",
+    "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.5.3/www-covidcast-classic-2.5.3.tgz",
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.72.5",


### PR DESCRIPTION
update to [COVIDcast v2.5.3](https://github.com/cmu-delphi/www-covidcast/releases/v2.5.3)