### PR TITLE
update to COVIDcast v2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2568,8 +2568,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.3/www-covidcast-2.5.3.tgz",
-      "integrity": "sha512-TxiapT12gAgSjogiEUfR+Eivtr1MWRI9iIAtK6mVWRRN2RFu8d8OjQwx+kg9Oqpl8+ETcECjOT/2qMQN3wJawA==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.6.0/www-covidcast-2.6.0.tgz",
+      "integrity": "sha512-VKPq1AMC4oRBWAXA5FzHG5wETHBAMf1rUZqkCTCr60HbNVFLrd/MaBwQ5/nczGbMgi9ONvWBCRMT8+Rp0W6igw==",
       "requires": {
         "uikit": "^3.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.0.1",
     "katex": "^0.13.11",
     "uikit": "^3.7.0",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.5.3/www-covidcast-2.5.3.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.6.0/www-covidcast-2.6.0.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.5.3/www-covidcast-classic-2.5.3.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v2.6.0](https://github.com/cmu-delphi/www-covidcast/releases/v2.6.0)