### PR TITLE
update to COVIDcast Classic v2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,17 +2575,10 @@
       }
     },
     "www-covidcast-classic": {
-      "version": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.5.3/www-covidcast-classic-2.5.3.tgz",
-      "integrity": "sha512-uiIqXzt3gY/HMTBnw1ocgSupioYX+hgHWkF7+NjKgeADSqDYfOjmIMZkKHCMAKQjU/KibLvkxEglqiKCjBkLmg==",
+      "version": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.0/www-covidcast-classic-2.6.0.tgz",
+      "integrity": "sha512-IVZiIrR8rJqLYddNk5IMDA+ENR6dIoTfm39g+FaBj4U0qgiu3UwP4cSuXnxKsgeFkrCemWmfC61JHvUB3qKSUQ==",
       "requires": {
         "uikit": "^3.7.0"
-      },
-      "dependencies": {
-        "uikit": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/uikit/-/uikit-3.7.0.tgz",
-          "integrity": "sha512-N0xluQ380EHey26toMmNA4H2YLtvVRHMaYksG31qDxW2VaAAf9i0Q0aT82zeMdrK2Tx9sqnHz6GaOMTIYYM0ZQ=="
-        }
       }
     },
     "www-epivis": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "katex": "^0.13.11",
     "uikit": "^3.7.0",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.6.0/www-covidcast-2.6.0.tgz",
-    "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.5.3/www-covidcast-classic-2.5.3.tgz",
+    "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.0/www-covidcast-classic-2.6.0.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },
   "devDependencies": {


### PR DESCRIPTION
update to [COVIDcast Classic v2.6.0](https://github.com/cmu-delphi/www-covidcast-classic/releases/v2.6.0)

This includes the updated vaccine signal, which some of facebook's partners have asked be added to classic. we're running down some contacts to see who exactly is using classic and what we can do to get them to move to the dashboard instead, but in the meantime...