### PR TITLE
update to COVIDcast v2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2568,8 +2568,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.7.0/www-covidcast-2.7.0.tgz",
-      "integrity": "sha512-mes3tWZbbJWtwjsCXP27EvXAed2l5xyNBQEzfvDQ/L+1eXt182duTyoRxwfHpyCOOZUbRGj/w+d0LYp2GWEU4Q==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.7.1/www-covidcast-2.7.1.tgz",
+      "integrity": "sha512-IibhilfrCOq7jj2vBn04TbeKHOwqlKlWHFKCwpi1M7QFhSGksaA2LuBaxxDN240RdXiQ6eIZlXz6nAdf0RMHHQ==",
       "requires": {
         "uikit": "^3.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.0.1",
     "katex": "^0.13.11",
     "uikit": "^3.7.0",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.7.0/www-covidcast-2.7.0.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.7.1/www-covidcast-2.7.1.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.0/www-covidcast-classic-2.6.0.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v2.7.1](https://github.com/cmu-delphi/www-covidcast/releases/v2.7.1)