### PR TITLE
update to COVIDcast v2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2505,8 +2505,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.7.2/www-covidcast-2.7.2.tgz",
-      "integrity": "sha512-CYUsj0z/LLxWknKrJPuBlPitn/lKp/UNwJRr1FgXgUr5h6crk0p7KGhdK4FtSn+eSIbQY63O5d+C07Q+AeJt/g==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.8.0/www-covidcast-2.8.0.tgz",
+      "integrity": "sha512-0mkJm8ZHCGlaM7l2rnUkKjpbVlj51MWmvaLlISASkQs0PBD+iPf2qq1UJXYnOFYWTuC5uhZ1XVi+UMpS6+UOhw==",
       "requires": {
         "uikit": "^3.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.2.0",
     "katex": "^0.13.13",
     "uikit": "^3.7.2",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.7.2/www-covidcast-2.7.2.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.8.0/www-covidcast-2.8.0.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.0/www-covidcast-classic-2.6.0.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v2.8.0](https://github.com/cmu-delphi/www-covidcast/releases/v2.8.0)