### PR TITLE
refactor: resize images in publications

### DIFF
--- a/themes/delphi/layouts/partials/coe/research-papers.html
+++ b/themes/delphi/layouts/partials/coe/research-papers.html
@@ -11,8 +11,14 @@
         <div class="card-grid-item uk-card uk-card-default uk-card-small">
           <div class="card-grid-item-date">{{ .year }}</div>
           <picture>
-            <source srcset="{{ ($img.Resize "webp").RelPermalink }}" type="image/webp" />
-            <img class="card-grid-item-img" src="{{ $img.RelPermalink }}" width="240" height="300" alt="Banner" />
+            <source srcset="{{ ($img.Resize "300x webp Gaussian").RelPermalink }}" type="image/webp" />
+            <img
+              class="card-grid-item-img"
+              src="{{ ($img).RelPermalink }}"
+              width="300"
+              height="300"
+              alt="{{ .title }}"
+            />
           </picture>
           <div class="uk-flex uk-flex-column">
             <div class="uk-card-body uk-flex-1">

--- a/themes/delphi/layouts/shortcodes/research-papers.html
+++ b/themes/delphi/layouts/shortcodes/research-papers.html
@@ -4,7 +4,10 @@
     {{ $img := $images.GetMatch (path.Join "images" .image) }}
     <div class="card-grid-item uk-card uk-card-default uk-card-small">
       <div class="card-grid-item-date">{{ .year }}</div>
-      <img class="card-grid-item-img" src="{{ $img.RelPermalink }}" width="240" height="300" alt="Banner" />
+      <picture>
+        <source srcset="{{ ($img.Resize "300x webp Gaussian").RelPermalink }}" type="image/webp" />
+        <img class="card-grid-item-img" src="{{ ($img).RelPermalink }}" width="300" height="300" alt="{{ .title }}" />
+      </picture>
       <div class="uk-flex uk-flex-column">
         <div class="uk-card-body uk-flex-1">
           <h3 class="uk-card-title"><a href="{{ .link }}" class="uk-link-heading">{{ .title }}</a></h3>


### PR DESCRIPTION
maybe #463 

by enforcing a uniform size (at render time) for the publication images, similar to the blog images