### PR TITLE
update to COVIDcast v2.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2398,8 +2398,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.8.0/www-covidcast-2.8.0.tgz",
-      "integrity": "sha512-0mkJm8ZHCGlaM7l2rnUkKjpbVlj51MWmvaLlISASkQs0PBD+iPf2qq1UJXYnOFYWTuC5uhZ1XVi+UMpS6+UOhw==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.8.1/www-covidcast-2.8.1.tgz",
+      "integrity": "sha512-rfcyI8I7aHAWGGvYXqJA/qM5cbEZwkw2I9K+VKmaRS1Uw4D8OYBY/tNlQ0l7Ln+XGhto6md/QHZpPF8TKvBkIA==",
       "requires": {
         "uikit": "^3.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.3.1",
     "katex": "^0.15.1",
     "uikit": "^3.9.2",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.8.0/www-covidcast-2.8.0.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v2.8.1/www-covidcast-2.8.1.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.0/www-covidcast-classic-2.6.0.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v2.8.1](https://github.com/cmu-delphi/www-covidcast/releases/v2.8.1)