### PR TITLE
Link to PNAS papers on public site

### DIFF
--- a/content/covid19/_index.md
+++ b/content/covid19/_index.md
@@ -4,11 +4,11 @@ linkTitle: COVID-19
 layout: single
 ---
 
-In March 2020, Delphi pivoted from seasonal epidemic forecasting to COVID-19 tracking. Since then, we’ve created and maintained the nation’s largest public repository of diverse, geographically-detailed, real-time indicators of COVID-19 activity in the U.S. Our indicators cover every rung of the severity pyramid, and are freely available through our public API or our data export tool.
+In March 2020, Delphi pivoted from seasonal epidemic forecasting to COVID-19 tracking. Since then, we’ve created and maintained the nation’s largest public repository of diverse, geographically-detailed, real-time indicators of COVID-19 activity in the U.S. Our indicators cover every rung of the severity pyramid, and are freely available through [our public API]({{< apiref "api/covidcast.html" >}}) or our [data export tool]({{< relref "covidcast/export" >}}).
 
 Several of the underlying data sources (on which these indicators are built) would not exist or be publicly available without our efforts. This includes:
 
-* A massive national daily survey we’re running in partnership with Facebook. Over 20 million Americans have answered the survey since April 2020, providing real-time insights into, e.g., self-reported symptoms, mask wearing, testing, and contacts, all broken down by various demographics.
+* A [massive national daily survey]({{< relref "covid19/ctis" >}}) we’re running in partnership with Facebook. Over 20 million Americans have answered the survey since April 2020, providing real-time insights into, e.g., self-reported symptoms, mask wearing, testing, and contacts, all broken down by various demographics.
 * An enormous database of medical insurance claims that have been de-identified in accordance with HIPAA privacy regulations, covering more than half the US population, made possible through health system partners including Change Healthcare. We use this to produce a new syndromic COVID-19 indicator based on doctor visits, and other indicators based on hospitalizations and ICU admissions.
 
-We have selected a small number of indicators to showcase in COVIDcast, a visualization system that helps place pandemic activity in geographic and temporal context. It includes a notion of correlation across time, for example, a spike in cases is often followed by a spike in hospital admissions some number of days later.
+An overview of our work and data was [published in the *Proceedings of the National Academy of Sciences*](https://doi.org/10.1073/pnas.2111452118). We have selected a small number of indicators to showcase in [COVIDcast]({{< relref "covidcast" >}}), a visualization system that helps place pandemic activity in geographic and temporal context. It includes a notion of correlation across time, for example, a spike in cases is often followed by a spike in hospital admissions some number of days later.

--- a/content/covid19/ctis.md
+++ b/content/covid19/ctis.md
@@ -58,6 +58,13 @@ The [Symptom Data Challenge](https://www.symptomchallenge.org/) challenged parti
 
 ### Publications
 
+- J. Salomon, A. Reinhart, A. Bilinski, E. J. Chua, W. La Motte-Kerr, M. M.
+  Rönn, M. B. Reitsma, K. A. Morris, S. LaRocca, T. H. Farag, F. Kreuter, R.
+  Rosenfeld, and R. J. Tibshirani (2021). [The US COVID-19 Trends and Impact
+  Survey: Continuous real-time measurement of COVID-19 symptoms, risks,
+  protective behaviors, testing, and
+  vaccination](https://doi.org/10.1073/pnas.2111454118). *Proceedings of the
+  National Academy of Sciences* 118 (51) e2111454118.
 - D. P. Do and R. Frank (2021). [U.S. frontline workers and COVID-19 inequities](https://doi.org/10.1016/j.ypmed.2021.106833). *Preventive Medicine* 153, 106833.
 - W. C. King, M. Rubinstein, A. Reinhart, and R. J. Mejia (2021). [COVID-19 vaccine hesitancy January-May 2021 among 18–64 year old US adults by employment and occupation](https://doi.org/10.1016/j.pmedr.2021.101569). *Preventive Medicine Reports* 24, 101569.
 - C. H. Sudre, A. Keshet, M. S. Graham, A. D. Joshi, S. Shilo, H. Rossman, B. Murray, E. Molteni, K. Klaser, L. D. Canas, M. Antonelli, L. H. Nguyen, D. A. Drew, M. Modat, J. Capdevila Pujol, S. Ganesh, J. Wolf, T. Meir, A. T. Chan, C. J. Steves, T. D. Spector, J. S. Brownstein, E. Segal, S. Ourselin, and C. M. Astley (2021). [Anosmia, ageusia, and other COVID-19-like symptoms in association with a positive SARS-CoV-2 test, across six national digital surveillance platforms: an observational study](https://doi.org/10.1016/S2589-7500(21)00115-1). *The Lancet Digital Health* 3 (9), e577-e586.


### PR DESCRIPTION
We can go ahead and flog them in the next website release. Note I've also added some other links to the COVIDcast page, just to make it easier to navigate to related things from that page; worth checking that I did those links right, since I'm not familiar with the ref/apiref syntax.