### PR TITLE
Attempt manual repair of package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2808,7 +2808,7 @@
     "node_modules/www-covidcast-classic": {
       "version": "2.6.0",
       "resolved": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.1/www-covidcast-classic-2.6.1.tgz",
-      "integrity": "sha512-IVZiIrR8rJqLYddNk5IMDA+ENR6dIoTfm39g+FaBj4U0qgiu3UwP4cSuXnxKsgeFkrCemWmfC61JHvUB3qKSUQ==",
+      "integrity": "sha512-TYB71wzPFqAXWlnubNEUl1aR+vmSmsnc/yi2N5QFcsxIhz4JMiWx5+B5WJQLakjvuCTCmniAWXFh3k2/vjzdFA==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.7.0"


### PR DESCRIPTION
My conflict resolution in #571 was missing updated integrity hashes -- let's see if a manual repair will work, otherwise we'll need #573 