### PR TITLE
update to COVIDcast v3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "highlight.js": "^11.4.0",
         "katex": "^0.15.2",
         "uikit": "^3.10.1",
-        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.0.3/www-covidcast-3.0.3.tgz",
+        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.0/www-covidcast-3.2.0.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.1/www-covidcast-classic-2.6.1.tgz",
         "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
       },
@@ -2879,9 +2879,9 @@
       "dev": true
     },
     "node_modules/www-covidcast": {
-      "version": "3.0.3",
-      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.0.3/www-covidcast-3.0.3.tgz",
-      "integrity": "sha512-t97dLKIKyaeC6q74xmhgngJy1471JqJVrUymUxYREeHyzsEHOZlSbNJe9/1rRgsTei6z7I7PCRcywRuDGNFikg==",
+      "version": "3.2.0",
+      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.0/www-covidcast-3.2.0.tgz",
+      "integrity": "sha512-67+RD92DksEOiKigvgRvpWUM/I7ZYRAx4hAKAK67BD6r7G1mXpCntI23RMPkQcN/8d7wpIPZkhbRblztgvcm5g==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.9.3"
@@ -5079,8 +5079,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.0.3/www-covidcast-3.0.3.tgz",
-      "integrity": "sha512-t97dLKIKyaeC6q74xmhgngJy1471JqJVrUymUxYREeHyzsEHOZlSbNJe9/1rRgsTei6z7I7PCRcywRuDGNFikg==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.0/www-covidcast-3.2.0.tgz",
+      "integrity": "sha512-67+RD92DksEOiKigvgRvpWUM/I7ZYRAx4hAKAK67BD6r7G1mXpCntI23RMPkQcN/8d7wpIPZkhbRblztgvcm5g==",
       "requires": {
         "uikit": "^3.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.4.0",
     "katex": "^0.15.2",
     "uikit": "^3.10.1",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.0.3/www-covidcast-3.0.3.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.0/www-covidcast-3.2.0.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.1/www-covidcast-classic-2.6.1.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v3.2.0](https://github.com/cmu-delphi/www-covidcast/releases/v3.2.0)