### PR TITLE
fix menu offset

### DIFF
--- a/themes/delphi/layouts/partials/nav.html
+++ b/themes/delphi/layouts/partials/nav.html
@@ -1,6 +1,6 @@
 {{- $currentPage := . -}}
 <nav class="nav-container">
-  <div class="uk-container uk-navbar-container" data-uk-navbar="offset: 0">
+  <div class="uk-container uk-navbar-container" data-uk-navbar="offset: -13">
     <ul class="uk-navbar-nav">
       <li>
         <a class="nav-cmu-delphi-logo" href="{{ relref . "/" }}" title="Go to the main page"
@@ -11,7 +11,7 @@
     <ul class="uk-navbar-nav nav-entries">
       {{ range .Site.Menus.main.ByWeight }}
         <li
-          class="nav-entry {{ if (eq $currentPage.Section .Identifier) -}}uk-active{{- end -}} {{ if .HasChildren -}}
+          class="nav-entry {{ if (eq $currentPage.Section .Identifier) -}}uk-active{{ end -}} {{ if .HasChildren -}}
             uk-parent
           {{- end -}}"
         >


### PR DESCRIPTION
closes #616

most likely related to https://github.com/uikit/uikit/releases/tag/v3.13.6

not sure why we see different behaviors. I just saw the "buggy" version in my local system. 