### PR TITLE
update dependency for create-pull-request

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -25,7 +25,7 @@ jobs:
           echo -n "::set-output name=next_tag::"
           npm version --no-git-tag-version ${{ github.event.inputs.versionName }}
       - name: Create pull request into main
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           branch: release/${{ steps.version.outputs.next_tag }}
           commit-message: "chore: release ${{ steps.version.outputs.next_tag }}"


### PR DESCRIPTION
closes #613

looking at https://github.com/peter-evans/create-pull-request/releases the breaking change shouldn't affect us, since we are not using this feature.