### PR TITLE
update to COVIDcast v3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "highlight.js": "^11.5.1",
         "katex": "^0.15.3",
         "uikit": "^3.14.1",
-        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.1/www-covidcast-3.2.1.tgz",
+        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.2/www-covidcast-3.2.2.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.2/www-covidcast-classic-2.6.2.tgz",
         "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
       },
@@ -2895,9 +2895,9 @@
       "dev": true
     },
     "node_modules/www-covidcast": {
-      "version": "3.2.1",
-      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.1/www-covidcast-3.2.1.tgz",
-      "integrity": "sha512-g8ddK57vqxlvHf6Vnw/VzTK68n+uU7SnRz1jJ1FLvhDz4wcraBeEQCU/P78/sVVQE6UinPQe4DITPt6k79jSQw==",
+      "version": "3.2.2",
+      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.2/www-covidcast-3.2.2.tgz",
+      "integrity": "sha512-8RQo55GsO4uaG1ASO647ufVUbwInYsspExl0nsb2Ruph32TQlMpOdCoDckAt8c+BmVbzEVX8hXlJa/RszgrFHg==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.9.3"
@@ -5102,8 +5102,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.1/www-covidcast-3.2.1.tgz",
-      "integrity": "sha512-g8ddK57vqxlvHf6Vnw/VzTK68n+uU7SnRz1jJ1FLvhDz4wcraBeEQCU/P78/sVVQE6UinPQe4DITPt6k79jSQw==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.2/www-covidcast-3.2.2.tgz",
+      "integrity": "sha512-8RQo55GsO4uaG1ASO647ufVUbwInYsspExl0nsb2Ruph32TQlMpOdCoDckAt8c+BmVbzEVX8hXlJa/RszgrFHg==",
       "requires": {
         "uikit": "^3.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.5.1",
     "katex": "^0.15.3",
     "uikit": "^3.14.1",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.1/www-covidcast-3.2.1.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.2/www-covidcast-3.2.2.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.2/www-covidcast-classic-2.6.2.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.1/www-epivis-2.0.1.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v3.2.2](https://github.com/cmu-delphi/www-covidcast/releases/v3.2.2)