### PR TITLE
Link to CTIS Methodology Report

### DIFF
--- a/content/covid19/ctis.md
+++ b/content/covid19/ctis.md
@@ -15,7 +15,7 @@ Such detailed data has never before been available during a public health emerge
 
 An international version of the survey was conducted by the University of Maryland in collaboration with Facebook. Its data [is available separately](https://covidmap.umd.edu/).
 
-Detailed technical documentation about the survey is available on our [site for data users](https://cmu-delphi.github.io/delphi-epidata/symptom-survey/).
+The [CTIS Methodology Report](https://dataforgood.facebook.com/dfg/resources/CTIS-methodology-report) gives technical details about the survey design and data collection process, and detailed technical documentation about the survey is available on our [site for data users](https://cmu-delphi.github.io/delphi-epidata/symptom-survey/).
 
 ## What are the surveys for?
 


### PR DESCRIPTION
The Methodology Report is meant to be the canonical source for information about the design of the survey, so we should provide a link to it here. Once the data is archived, we can change this to a link to the central documentation for the survey, including the methodology report, codebooks, and archival data.