### PR TITLE
update to COVIDcast Classic v2.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2192,8 +2192,8 @@
       }
     },
     "www-covidcast-classic": {
-      "version": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.2/www-covidcast-classic-2.6.2.tgz",
-      "integrity": "sha512-XFPy+BXn3D4AIHbnm7n6z+oxxisE4X5RdDB+8gbLdoCf0U1CZ3ZcnafJzuXobP0sz961W89+nKPxY+k0Jk6dwQ==",
+      "version": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.3/www-covidcast-classic-2.6.3.tgz",
+      "integrity": "sha512-gXcSF33Qii+mnew30jV6ow7rCfUdX+ch/GcQzSUB0y+89ROX+U6Ln/M2xgIOdsm+GiGRedKqxMeHyqPMYzpBkw==",
       "requires": {
         "uikit": "^3.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "katex": "^0.16.0",
     "uikit": "^3.14.3",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.3/www-covidcast-3.2.3.tgz",
-    "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.2/www-covidcast-classic-2.6.2.tgz",
+    "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.3/www-covidcast-classic-2.6.3.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz"
   },
   "devDependencies": {


### PR DESCRIPTION
update to [COVIDcast Classic v2.6.3](https://github.com/cmu-delphi/www-covidcast-classic/releases/v2.6.3)