### PR TITLE
Fix nav spacing issues

### DIFF
--- a/themes/delphi/assets/css/layout/_header_footer.scss
+++ b/themes/delphi/assets/css/layout/_header_footer.scss
@@ -49,6 +49,7 @@ $mobile-margin: 15px;
 .nav-entries {
   flex-shrink: 1;
   overflow: hidden;
+  column-gap: 0;
 }
 
 .nav-spacer {

--- a/themes/delphi/layouts/partials/nav.html
+++ b/themes/delphi/layouts/partials/nav.html
@@ -1,6 +1,6 @@
 {{- $currentPage := . -}}
 <nav class="nav-container">
-  <div class="uk-container uk-navbar-container" data-uk-navbar="offset: -13">
+  <div class="uk-container uk-navbar-container" data-uk-navbar="offset: 0px">
     <ul class="uk-navbar-nav">
       <li>
         <a class="nav-cmu-delphi-logo" href="{{ relref . "/" }}" title="Go to the main page"


### PR DESCRIPTION
* Fixes #692
* Fixes excessive column gap which pushed API link offscreen in one of the dependabot uikit updates. [View in dev branch preview](https://dev--cmu-delphi-main.netlify.app/) or screenshot here:

![image](https://user-images.githubusercontent.com/1158666/196287942-0415d882-7911-4b07-91c2-7f42a89f7bf5.png)

## Changelog

Remove column gap (from custom scss) and offset (from theme layout file).

NB setting offset to 0 instead of 0px gives us back #616 behavior, not sure why