### PR TITLE
update to COVIDcast Classic v2.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2192,8 +2192,8 @@
       }
     },
     "www-covidcast-classic": {
-      "version": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.4/www-covidcast-classic-2.6.4.tgz",
-      "integrity": "sha512-XRvo8dq1S+JVSOBDAIdJ+UxsvAfIEl9SI6pGwqlBkh99s3XerLFh3aPVgynLJ2mZ++sqYtIyiAJZPgM3QTK5sw==",
+      "version": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.5/www-covidcast-classic-2.6.5.tgz",
+      "integrity": "sha512-Xq0VmYY6k2NwFWcwUymeF/URCnki2v+hCn7knPSnqjPPKxLxXtpkNI/eIw8ibWnnLxT3Yxa/87FSBIV7xikM4g==",
       "requires": {
         "uikit": "^3.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "katex": "^0.16.3",
     "uikit": "^3.15.11",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.3/www-covidcast-3.2.3.tgz",
-    "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.4/www-covidcast-classic-2.6.4.tgz",
+    "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.5/www-covidcast-classic-2.6.5.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz"
   },
   "devDependencies": {


### PR DESCRIPTION
update to [COVIDcast Classic v2.6.5](https://github.com/cmu-delphi/www-covidcast-classic/releases/v2.6.5)