### PR TITLE
Shorten title for ED position on home page hero

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ layout: landing
 
 carousel:
   - pre: Delphi Careers
-    title: CMU Seeking Executive Director for Public Health Initiatives and Delphi Group
+    title: Seeking Executive Director for CMU Public Health Initiatives and Delphi Group
     ref: careers
     alt: View Position
     image: cmu-bldg-7-hero.jpg

--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ layout: landing
 
 carousel:
   - pre: Delphi Careers
-    title: Seeking Executive Director for Carnegie Mellon Public Health Initiatives and Delphi
+    title: Seeking Executive Director to Lead Carnegie Mellon Public Health Initiatives and Delphi
     ref: careers
     alt: View Position
     image: cmu-bldg-7-hero.jpg

--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ layout: landing
 
 carousel:
   - pre: Delphi Careers
-    title: CMU Seeking an Executive Director for Delphi Research Group & Strategic Coordinator of Public Health Research Initiatives
+    title: CMU Seeking Executive Director for Public Health Initiatives and Delphi Group
     ref: careers
     alt: View Position
     image: cmu-bldg-7-hero.jpg

--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ layout: landing
 
 carousel:
   - pre: Delphi Careers
-    title: Seeking Executive Director for CMU Public Health Initiatives and Delphi Group
+    title: Seeking Executive Director for Carnegie Mellon Public Health Initiatives and Delphi
     ref: careers
     alt: View Position
     image: cmu-bldg-7-hero.jpg


### PR DESCRIPTION
Shorten title for ED position on home page hero
-on some devices (e.g., mobile phone) the long title prevents access to 'View Position' button 
-preventing access to this button limits ease of access to the Careers page with details of ED position and link to apply