### PR TITLE
docker refactor for stable environment to convert Rmd blog post to html

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,15 @@ In order to convert the Rmd files to HTML files for Hugo you also need to:
 1. Activate the environment: `conda activate www-main`
 1. Install extra R dependencies: `Rscript ./dependencies.R`
 
-As an alternative you can use Docker and Docker Compose. Then it reduces to `docker-compose up -d` to create a docker container for the current environment. In the following you would need to jump into the container to execute the upcoming command via `docker-compose exec r bash`.
+As an alternative you can use Docker and Docker Compose:
+1. `docker-compose up -d` to create a docker container for the current environment.
+1. `docker-compose exec r bash` to jump into the container. 
+1. `micromamba activate www-main` to activate the environment
 
+Now you have the environment ready to start converting .Rmd blog files to html.
 #### Commands
 
-1. Activate the environment: `conda activate www-main`
+
 1. Run blogdown to convert the files to HTML: `Rscript -e 'blogdown::build_site(local=TRUE, run_hugo=FALSE, build_rmd=TRUE)'`
    - `local=TRUE` similar to `-D` to process draft files
    - `run_hugo=FALSE` to manually run hugo

--- a/dependencies.R
+++ b/dependencies.R
@@ -3,6 +3,8 @@
 
 # blogdown::install_hugo()
 
+install.packages("ggrepel", repo="http://cran.rstudio.com/")
+install.packages("base64url", repo="http://cran.rstudio.com/")
 install.packages("covidcast", repo="http://cran.rstudio.com/")
 # devtools::install_github("cmu-delphi/covidcast", ref = "main",
 #                          upgrade = 'never',

--- a/devops/r.dockerfile
+++ b/devops/r.dockerfile
@@ -1,13 +1,13 @@
 # docker image for setting up an R environment
-FROM continuumio/miniconda
-
-RUN conda install --name base --channel conda-forge mamba=*
+FROM mambaorg/micromamba
 
 ADD ./environment.yml .
-RUN mamba env create -f environment.yml
 
+#RUN micromamba install --yes --name www-main --file environment.yml
+RUN micromamba env create -f environment.yml
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
 ADD ./dependencies.R .
 
-RUN conda run -n www-main Rscript ./dependencies.R
+RUN micromamba run -n www-main Rscript ./dependencies.R
 
 ENV PATH /opt/conda/envs/www-main/bin:$PATH

--- a/devops/r.dockerfile
+++ b/devops/r.dockerfile
@@ -3,7 +3,6 @@ FROM mambaorg/micromamba
 
 ADD ./environment.yml .
 
-#RUN micromamba install --yes --name www-main --file environment.yml
 RUN micromamba env create -f environment.yml
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 ADD ./dependencies.R .

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: www-main
 channels:
   - conda-forge
   - defaults
+  - conda-forge/linux-64
 dependencies:
   - gdal
   - python=3.9.1
@@ -13,7 +14,7 @@ dependencies:
   - r-devtools
   - r-directlabels
   - r-gridextra
-  - r-reticulate
+  - r-reticulate==1.22
   - r-blogdown
   - r-svglite
   - r-dplyr


### PR DESCRIPTION
### Description
- Replace miniconda base + mamba install with mambaorg/micromamba base image, reducing container build time by half.
- Adjust R dependencies and environment.yml to reflect recent changes in R packages.
- Pins reticulate at 1.22 to avoid a conda path problem with versions 1.23-28.

### Test
Rebuilt all blog post with setup with passing results.
<img width="993" alt="Screenshot 2023-01-31 at 11 41 19 AM" src="https://user-images.githubusercontent.com/118945681/215828176-98bedbfc-44ab-4ff5-bafb-5f58ef34de77.png">
