### PR TITLE
Update mission to include epidemiological tracking

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -176,7 +176,7 @@ relativeURLs = false
 
 [params]
     description = "Developing the Theory and Practice of Epidemiological Forecasting"
-    mission = "Develop the theory and practice of epidemiological forecasting, with a long-term vision of making this technology as universally accepted and useful as weather forecasting is today."
+    mission = "Develop the theory and practice of epidemiological tracking and forecasting, with a long-term vision of making this technology as universally accepted and useful as weather forecasting is today."
     apiUrl = "https://cmu-delphi.github.io/delphi-epidata"
     twitter = "CmuDelphi"
     contactForm = "https://docs.google.com/forms/d/e/1FAIpQLScqgT1fKZr5VWBfsaSp-DNaN03aV6EoZU4YljIzHJ1Wl_zmtg/viewform"


### PR DESCRIPTION
"Mission: Develop the theory and practice of epidemiological **tracking and** forecasting, with a long-term vision of making this technology as universally accepted and useful as weather forecasting is today."