### PR TITLE
Add default reviewers to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,11 @@ updates:
     target-branch: dev
     schedule:
       interval: "monthly"
+    reviewers: "cmu-delphi/code-reviewers"
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: dev
     schedule:
       interval: "monthly"
+    reviewers: "cmu-delphi/code-reviewers"


### PR DESCRIPTION
Dependabot already checks for updated library versions each month; this change just tells it to auto-assign someone from the code review rotation.