### PR TITLE
Update workflows for Katie's departure

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -32,7 +32,7 @@ jobs:
           base: main
           title: Release ${{ steps.version.outputs.next_tag }}
           labels: chore
-          reviewers: krivard
-          # assignees:
+          # reviewers: 
+          assignees: melange396
           body: |
             Releasing ${{ steps.version.outputs.next_tag }}.


### PR DESCRIPTION
Assign release PRs to george instead of Katie.

Also switch from reviewer to assignee; reviews are done via the release-runner rotation.
