### PR TITLE
update to COVIDcast v3.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "highlight.js": "^11.8.0",
         "katex": "^0.16.8",
         "uikit": "^3.17.0",
-        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.7/www-covidcast-3.2.7.tgz",
+        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.8/www-covidcast-3.2.8.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.5/www-covidcast-classic-2.6.5.tgz",
         "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz"
       },
@@ -2936,9 +2936,9 @@
       "dev": true
     },
     "node_modules/www-covidcast": {
-      "version": "3.2.7",
-      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.7/www-covidcast-3.2.7.tgz",
-      "integrity": "sha512-NX4dAvkKT9Q1Ato8j4CRP93u79iLtE3cvyq2Lfibl/bnqN/wP/0bkuRdpWYf+CjHDGT8UNmGIIfxytGBZ77riA==",
+      "version": "3.2.8",
+      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.8/www-covidcast-3.2.8.tgz",
+      "integrity": "sha512-Hfdwf6t1BqH44YcHUjeTFxNPsvaaT5ZO+Knc2975S6Jkbd4EEau0kO+6fMwvU+SJ0BN1L/8QpBxjZ26fp+9CQQ==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.16.13"
@@ -5009,8 +5009,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.7/www-covidcast-3.2.7.tgz",
-      "integrity": "sha512-NX4dAvkKT9Q1Ato8j4CRP93u79iLtE3cvyq2Lfibl/bnqN/wP/0bkuRdpWYf+CjHDGT8UNmGIIfxytGBZ77riA==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.8/www-covidcast-3.2.8.tgz",
+      "integrity": "sha512-Hfdwf6t1BqH44YcHUjeTFxNPsvaaT5ZO+Knc2975S6Jkbd4EEau0kO+6fMwvU+SJ0BN1L/8QpBxjZ26fp+9CQQ==",
       "requires": {
         "uikit": "^3.16.13"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.8.0",
     "katex": "^0.16.8",
     "uikit": "^3.17.0",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.7/www-covidcast-3.2.7.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.8/www-covidcast-3.2.8.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.5/www-covidcast-classic-2.6.5.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v3.2.8](https://github.com/cmu-delphi/www-covidcast/releases/v3.2.8)