### PR TITLE
Upgrade to node v18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - uses: actions/cache@v4.0.1
         with:
           path: ~/.npm

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: Extract version
         id: extract_version
         run: node -pe "'::set-output name=version::' + require('./package.json').version"
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: Cache Node.js modules
         uses: actions/cache@v4.0.1
         with:

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,25 +3,25 @@ publish = "public"
 command = "npm ci && hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.production.environment]
-HUGO_VERSION = "0.87.0"
+HUGO_VERSION = "0.121.0"
 HUGO_ENV = "production"
-NODE_VERSION = "14.16.0"
-NPM_VERSION = "6.14.11"
+NODE_VERSION = "18.20.0"
+NPM_VERSION = "10.5.0"
 
 [context.deploy-preview]
 command = "npm ci && hugo --gc --minify --buildDrafts --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.87.0"
+HUGO_VERSION = "0.121.0"
 HUGO_ENABLEGITINFO = "true"
-NODE_VERSION = "14.16.0"
-NPM_VERSION = "6.14.11"
+NODE_VERSION = "18.20.0"
+NPM_VERSION = "10.5.0"
 
 [context.branch-deploy]
 command = "npm ci && hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.87.0"
+HUGO_VERSION = "0.121.0"
 HUGO_ENABLEGITINFO = "true"
-NODE_VERSION = "14.16.0"
-NPM_VERSION = "6.14.11"
+NODE_VERSION = "18.20.0"
+NPM_VERSION = "10.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.1",
         "highlight.js": "^11.9.0",
-        "katex": "^0.16.9",
+        "katex": "^0.16.10",
         "uikit": "^3.19.1",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
         "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz"
       },
       "devDependencies": {
-        "hugo-bin": "^0.119.0",
+        "hugo-bin": "^0.122.3",
         "husky": "^8.0.3",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
@@ -1013,9 +1013,9 @@
       }
     },
     "node_modules/hugo-bin": {
-      "version": "0.119.0",
-      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.119.0.tgz",
-      "integrity": "sha512-RnjlxHKdOjo7i7yRX/001t53142tC9NTa5JVrnPCTpX2kNQQCz5XdI/WWX7emf0dNkxipj55Z58EsA2ft9W16g==",
+      "version": "0.122.3",
+      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.122.3.tgz",
+      "integrity": "sha512-t3is8dMTLhAQFwdZxCgMydF2Fd7+6SUPCGoIzsZnQ1ZqdGGSQUA1spga9MIwwMVbTjfG0wZ6efYLxyqqjPviDA==",
       "dev": true,
       "funding": [
         {
@@ -1198,9 +1198,9 @@
       "dev": true
     },
     "node_modules/katex": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
-      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "version": "0.16.10",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.10.tgz",
+      "integrity": "sha512-ZiqaC04tp2O5utMsl2TEZTXxa6WSC4yo0fv5ML++D3QZv/vx2Mct0mTlRx3O+uUkjfuAgOkzsCmq5MiUEsDDdA==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -3469,9 +3469,9 @@
       }
     },
     "hugo-bin": {
-      "version": "0.119.0",
-      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.119.0.tgz",
-      "integrity": "sha512-RnjlxHKdOjo7i7yRX/001t53142tC9NTa5JVrnPCTpX2kNQQCz5XdI/WWX7emf0dNkxipj55Z58EsA2ft9W16g==",
+      "version": "0.122.3",
+      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.122.3.tgz",
+      "integrity": "sha512-t3is8dMTLhAQFwdZxCgMydF2Fd7+6SUPCGoIzsZnQ1ZqdGGSQUA1spga9MIwwMVbTjfG0wZ6efYLxyqqjPviDA==",
       "dev": true,
       "requires": {
         "@xhmikosr/bin-wrapper": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz"
   },
   "devDependencies": {
-    "hugo-bin": "^0.119.0",
+    "hugo-bin": "^0.122.3",
     "husky": "^8.0.3",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",


### PR DESCRIPTION
The update to COVIDcast v3.2.10 in https://github.com/cmu-delphi/www-main/pull/957 broke the build when i merged it in...  I think this is because it introduced some dependencies that require node version 18+ (search https://github.com/cmu-delphi/www-main/blob/9bf7a77e17121279727046fb442e66891d6f25d8/package-lock.json for `node": ">=18` to find them).  Hopefully this appeases the build process....