### PR TITLE
fix COVIDcast reference

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -83,7 +83,7 @@ relativeURLs = false
 [[menu.main]]
     identifier = "epidemic-signals-covidcast"
     parent = "epidemic-signals"
-    name = "COVIDcast Dashboard"
+    name = "Delphi Epidata Dashboard"
     url = "/covidcast/"
     weight = 20
 [[menu.main]]


### PR DESCRIPTION
Somewhere along the way, a "COVIDcast" rename got lost:
- renamed here: https://github.com/cmu-delphi/www-main/pull/954/files#diff-28043ff911f28a5cb5742f7638363546311225a63eabc365af5356c70d4deb77R122
- changed back here: https://github.com/cmu-delphi/www-main/pull/962/files#diff-28043ff911f28a5cb5742f7638363546311225a63eabc365af5356c70d4deb77R86

Im not sure how it happened, maybe a funky merge?  ¯\\\_(ツ)_/¯  Regardless, its an easy fix!