### PR TITLE
update to EPIVis v2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uikit": "^3.21.6",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz"
+        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.2/www-epivis-2.1.2.tgz"
       },
       "devDependencies": {
         "hugo-bin": "^0.122.7",
@@ -2654,9 +2654,9 @@
       }
     },
     "node_modules/www-epivis": {
-      "version": "2.0.3",
-      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz",
-      "integrity": "sha512-zkqK7/3a2/R0PwaJwWIm35SulcGJ58qF8yS2xSr5SOBDT7zExGmBO+vrRx2j90pKbGUyYIYI503QKh175jiTAg==",
+      "version": "2.1.2",
+      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.2/www-epivis-2.1.2.tgz",
+      "integrity": "sha512-+rZSbeW0A0HbLGzyfj9J2kqDnVqEcbD6Fha1rUCvfMXGeeJFOtF6O/9U8wH+B9Y3/QPMEuGVatxtXaneMAslww==",
       "dependencies": {
         "uikit": "^3.15.5"
       }
@@ -4509,8 +4509,8 @@
       }
     },
     "www-epivis": {
-      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz",
-      "integrity": "sha512-zkqK7/3a2/R0PwaJwWIm35SulcGJ58qF8yS2xSr5SOBDT7zExGmBO+vrRx2j90pKbGUyYIYI503QKh175jiTAg==",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.2/www-epivis-2.1.2.tgz",
+      "integrity": "sha512-+rZSbeW0A0HbLGzyfj9J2kqDnVqEcbD6Fha1rUCvfMXGeeJFOtF6O/9U8wH+B9Y3/QPMEuGVatxtXaneMAslww==",
       "requires": {
         "uikit": "^3.15.5"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uikit": "^3.21.6",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.0.3/www-epivis-2.0.3.tgz"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.2/www-epivis-2.1.2.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.122.7",


### PR DESCRIPTION
update to [EPIVis v2.1.2](https://github.com/cmu-delphi/www-epivis/releases/v2.1.2)

Releasing v2.1.1.

Includes changes since v2.0.3:

* functional:
  * https://github.com/cmu-delphi/www-epivis/pull/37 
  * https://github.com/cmu-delphi/www-epivis/pull/36 
* dependency updates:
  * https://github.com/cmu-delphi/www-epivis/pull/31 
  * https://github.com/cmu-delphi/www-epivis/pull/34 
  * https://github.com/cmu-delphi/www-epivis/pull/40 
  * https://github.com/cmu-delphi/www-epivis/pull/39 
