### PR TITLE
update to EPIVis v2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uikit": "^3.21.9",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.2/www-epivis-2.1.2.tgz"
+        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.3/www-epivis-2.1.3.tgz"
       },
       "devDependencies": {
         "hugo-bin": "^0.127.0",
@@ -2598,9 +2598,9 @@
       }
     },
     "node_modules/www-epivis": {
-      "version": "2.1.2",
-      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.2/www-epivis-2.1.2.tgz",
-      "integrity": "sha512-+rZSbeW0A0HbLGzyfj9J2kqDnVqEcbD6Fha1rUCvfMXGeeJFOtF6O/9U8wH+B9Y3/QPMEuGVatxtXaneMAslww==",
+      "version": "2.1.3",
+      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.3/www-epivis-2.1.3.tgz",
+      "integrity": "sha512-F4gyz+OMoC5p5uSw7i+4UOcaP9kr91kV+vOOXe0Lt0BkQEOm0TA6lAp3GYewktYbppLBcJEs/Bmpj3/k+dmERg==",
       "dependencies": {
         "uikit": "^3.15.5"
       }
@@ -4393,8 +4393,8 @@
       }
     },
     "www-epivis": {
-      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.2/www-epivis-2.1.2.tgz",
-      "integrity": "sha512-+rZSbeW0A0HbLGzyfj9J2kqDnVqEcbD6Fha1rUCvfMXGeeJFOtF6O/9U8wH+B9Y3/QPMEuGVatxtXaneMAslww==",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.3/www-epivis-2.1.3.tgz",
+      "integrity": "sha512-F4gyz+OMoC5p5uSw7i+4UOcaP9kr91kV+vOOXe0Lt0BkQEOm0TA6lAp3GYewktYbppLBcJEs/Bmpj3/k+dmERg==",
       "requires": {
         "uikit": "^3.15.5"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uikit": "^3.21.9",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.2/www-epivis-2.1.2.tgz"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.3/www-epivis-2.1.3.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.127.0",


### PR DESCRIPTION
update to [EPIVis v2.1.3](https://github.com/cmu-delphi/www-epivis/releases/v2.1.3)