### PR TITLE
Migrate micromamba setup action

### DIFF
--- a/.github/workflows/blog.yaml
+++ b/.github/workflows/blog.yaml
@@ -17,17 +17,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 3
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
           micromamba-version: latest
           log-level: debug
+          cache-environment: true
+          cache-environment-key: environment-${{ steps.date.outputs.date }}
         env:
           ACTIONS_STEP_DEBUG: true
-      - name: Get Date
-        id: get-date
-        run: echo "name=today::$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-        shell: bash
       - name: Install R dependencies
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blog.yaml
+++ b/.github/workflows/blog.yaml
@@ -21,16 +21,13 @@ jobs:
         with:
           environment-file: environment.yml
           micromamba-version: latest
+          log-level: debug
+        env:
+          ACTIONS_STEP_DEBUG: true
       - name: Get Date
         id: get-date
         run: echo "name=today::$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
         shell: bash
-      - name: Create environment
-        run: micromamba env create -n www-main-micromamba -f environment.yml
-      - name: micromamba info
-        run: |
-          micromamba info
-          micromamba list
       - name: Install R dependencies
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blog.yaml
+++ b/.github/workflows/blog.yaml
@@ -23,8 +23,6 @@ jobs:
           micromamba-version: latest
           log-level: debug
           cache-environment: true
-        env:
-          ACTIONS_STEP_DEBUG: true
       - name: Install R dependencies
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blog.yaml
+++ b/.github/workflows/blog.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 3
-      - uses: mamba-org/provision-with-micromamba@v16
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
           micromamba-version: latest

--- a/.github/workflows/blog.yaml
+++ b/.github/workflows/blog.yaml
@@ -17,16 +17,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 3
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
           micromamba-version: latest
           log-level: debug
           cache-environment: true
-          cache-environment-key: environment-${{ steps.date.outputs.date }}
         env:
           ACTIONS_STEP_DEBUG: true
       - name: Install R dependencies


### PR DESCRIPTION

This PR might fix [this problem](https://github.com/cmu-delphi/www-main/actions/runs/11039018072/job/30663544823
) thst's blocking blog build:

> Warning: This action is deprecated and no longer maintained. Please use mamba-org/setup-micromamba instead. See `[https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba`](https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba%60) for a migration guide.
