### PR TITLE
update to EPIVis v2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uikit": "^3.21.10",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.3/www-epivis-2.1.3.tgz"
+        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.4/www-epivis-2.1.4.tgz"
       },
       "devDependencies": {
         "hugo-bin": "^0.127.0",
@@ -2598,9 +2598,9 @@
       }
     },
     "node_modules/www-epivis": {
-      "version": "2.1.3",
-      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.3/www-epivis-2.1.3.tgz",
-      "integrity": "sha512-F4gyz+OMoC5p5uSw7i+4UOcaP9kr91kV+vOOXe0Lt0BkQEOm0TA6lAp3GYewktYbppLBcJEs/Bmpj3/k+dmERg==",
+      "version": "2.1.4",
+      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.4/www-epivis-2.1.4.tgz",
+      "integrity": "sha512-1IAZJMAUz9SJBmk7rXlaJuNm0y8wutD5CQDF333PG27buMCEvXwdgOkUnoYPaXTAMfEQ5U522cIibTY4vX4IlQ==",
       "dependencies": {
         "uikit": "^3.15.5"
       }
@@ -4393,8 +4393,8 @@
       }
     },
     "www-epivis": {
-      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.3/www-epivis-2.1.3.tgz",
-      "integrity": "sha512-F4gyz+OMoC5p5uSw7i+4UOcaP9kr91kV+vOOXe0Lt0BkQEOm0TA6lAp3GYewktYbppLBcJEs/Bmpj3/k+dmERg==",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.4/www-epivis-2.1.4.tgz",
+      "integrity": "sha512-1IAZJMAUz9SJBmk7rXlaJuNm0y8wutD5CQDF333PG27buMCEvXwdgOkUnoYPaXTAMfEQ5U522cIibTY4vX4IlQ==",
       "requires": {
         "uikit": "^3.15.5"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uikit": "^3.21.10",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.3/www-epivis-2.1.3.tgz"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.4/www-epivis-2.1.4.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.127.0",


### PR DESCRIPTION
update to [EPIVis v2.1.4](https://github.com/cmu-delphi/www-epivis/releases/v2.1.4)