### PR TITLE
update to COVIDcast v3.2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "highlight.js": "^11.9.0",
         "katex": "^0.16.11",
         "uikit": "^3.21.13",
-        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
+        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
         "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.4/www-epivis-2.1.4.tgz"
       },
@@ -2635,9 +2635,9 @@
       "dev": true
     },
     "node_modules/www-covidcast": {
-      "version": "3.2.10",
-      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
-      "integrity": "sha512-E8hvhEtfhi9V2jV58G9siNFPnsbwqR/1jP/IHd+X4xlmXQgw94oQv7k9a0blktO3Q2HVZYbzmD9nE/uk6L4WfA==",
+      "version": "3.2.11",
+      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
+      "integrity": "sha512-EXp3pu2kQYFBV6zcf8yAZVMUDAHd7yzDT15IlRmCq6BYmTx5O9iSJeLMKeW9bJZy/bzPr2eVvlpCrNlzMUrXcQ==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.16.13"
@@ -4465,8 +4465,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
-      "integrity": "sha512-E8hvhEtfhi9V2jV58G9siNFPnsbwqR/1jP/IHd+X4xlmXQgw94oQv7k9a0blktO3Q2HVZYbzmD9nE/uk6L4WfA==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
+      "integrity": "sha512-EXp3pu2kQYFBV6zcf8yAZVMUDAHd7yzDT15IlRmCq6BYmTx5O9iSJeLMKeW9bJZy/bzPr2eVvlpCrNlzMUrXcQ==",
       "requires": {
         "uikit": "^3.16.13"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.9.0",
     "katex": "^0.16.11",
     "uikit": "^3.21.13",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.10/www-covidcast-3.2.10.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.4/www-epivis-2.1.4.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v3.2.11](https://github.com/cmu-delphi/www-covidcast/releases/v3.2.11)