### PR TITLE
update to EPIVis v2.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uikit": "^3.21.13",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.5/www-epivis-2.1.5.tgz"
+        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.6/www-epivis-2.1.6.tgz"
       },
       "devDependencies": {
         "hugo-bin": "^0.127.0",
@@ -2652,9 +2652,9 @@
       }
     },
     "node_modules/www-epivis": {
-      "version": "2.1.5",
-      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.5/www-epivis-2.1.5.tgz",
-      "integrity": "sha512-Z009HgqZkc/Swz4vwP/dYNAeTs02tnvQc9ZZqToxtHqip7sIU61u/YFkxUeI+jOerRDxyra6VgP5LUyagatNVg==",
+      "version": "2.1.6",
+      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.6/www-epivis-2.1.6.tgz",
+      "integrity": "sha512-rzAAZRFB+7cqVY7Vu6U1xmUUrsdsAO6SowWNXilytDbzvmKY6xp6cccWFEv3WCwEqxkMZbV9jbnIjRamopRkdw==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.15.5"
@@ -4480,8 +4480,8 @@
       }
     },
     "www-epivis": {
-      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.5/www-epivis-2.1.5.tgz",
-      "integrity": "sha512-Z009HgqZkc/Swz4vwP/dYNAeTs02tnvQc9ZZqToxtHqip7sIU61u/YFkxUeI+jOerRDxyra6VgP5LUyagatNVg==",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.6/www-epivis-2.1.6.tgz",
+      "integrity": "sha512-rzAAZRFB+7cqVY7Vu6U1xmUUrsdsAO6SowWNXilytDbzvmKY6xp6cccWFEv3WCwEqxkMZbV9jbnIjRamopRkdw==",
       "requires": {
         "uikit": "^3.15.5"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uikit": "^3.21.13",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.5/www-epivis-2.1.5.tgz"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.6/www-epivis-2.1.6.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.127.0",


### PR DESCRIPTION
update to [EPIVis v2.1.6](https://github.com/cmu-delphi/www-epivis/releases/v2.1.6)