### PR TITLE
update to EPIVis v2.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uikit": "^3.21.13",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.7/www-epivis-2.1.7.tgz"
+        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.8/www-epivis-2.1.8.tgz"
       },
       "devDependencies": {
         "hugo-bin": "^0.127.0",
@@ -2652,9 +2652,9 @@
       }
     },
     "node_modules/www-epivis": {
-      "version": "2.1.7",
-      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.7/www-epivis-2.1.7.tgz",
-      "integrity": "sha512-zYxpIoTDR0Z3OJ6dRNzYkuv0rtQerVDjlyFFnp3upwuyMJIC+v4aqwNfSi069xRNUUOr6s3UZXXv1KKMH0toAg==",
+      "version": "2.1.8",
+      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.8/www-epivis-2.1.8.tgz",
+      "integrity": "sha512-yPnP6kBcVfGn6AKnlWbjl1hArnQ26lTfy3CpFqAEpCvmeNK2bVC+IJZMXFQIa2/06X7KmMo5gBbNFniO/6R70g==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.15.5"
@@ -4480,8 +4480,8 @@
       }
     },
     "www-epivis": {
-      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.7/www-epivis-2.1.7.tgz",
-      "integrity": "sha512-zYxpIoTDR0Z3OJ6dRNzYkuv0rtQerVDjlyFFnp3upwuyMJIC+v4aqwNfSi069xRNUUOr6s3UZXXv1KKMH0toAg==",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.8/www-epivis-2.1.8.tgz",
+      "integrity": "sha512-yPnP6kBcVfGn6AKnlWbjl1hArnQ26lTfy3CpFqAEpCvmeNK2bVC+IJZMXFQIa2/06X7KmMo5gBbNFniO/6R70g==",
       "requires": {
         "uikit": "^3.15.5"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uikit": "^3.21.13",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.7/www-epivis-2.1.7.tgz"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.8/www-epivis-2.1.8.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.127.0",


### PR DESCRIPTION
update to [EPIVis v2.1.8](https://github.com/cmu-delphi/www-epivis/releases/v2.1.8)