### PR TITLE
update to COVIDcast v3.2.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "highlight.js": "^11.9.0",
         "katex": "^0.16.11",
         "uikit": "^3.21.13",
-        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
+        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
         "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.9/www-epivis-2.1.9.tgz"
       },
@@ -2635,9 +2635,9 @@
       "dev": true
     },
     "node_modules/www-covidcast": {
-      "version": "3.2.11",
-      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
-      "integrity": "sha512-EXp3pu2kQYFBV6zcf8yAZVMUDAHd7yzDT15IlRmCq6BYmTx5O9iSJeLMKeW9bJZy/bzPr2eVvlpCrNlzMUrXcQ==",
+      "version": "3.2.12",
+      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
+      "integrity": "sha512-lkQQ+ZIxpipied3zkHV4MTdDIaEljUjY9ObmmgtfKQjTTTQKinGhdrq6belVEwxKLF2p7x03A7T8vfmyPoMYbw==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.16.13"
@@ -4466,8 +4466,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
-      "integrity": "sha512-EXp3pu2kQYFBV6zcf8yAZVMUDAHd7yzDT15IlRmCq6BYmTx5O9iSJeLMKeW9bJZy/bzPr2eVvlpCrNlzMUrXcQ==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
+      "integrity": "sha512-lkQQ+ZIxpipied3zkHV4MTdDIaEljUjY9ObmmgtfKQjTTTQKinGhdrq6belVEwxKLF2p7x03A7T8vfmyPoMYbw==",
       "requires": {
         "uikit": "^3.16.13"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.9.0",
     "katex": "^0.16.11",
     "uikit": "^3.21.13",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.11/www-covidcast-3.2.11.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.9/www-epivis-2.1.9.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v3.2.12](https://github.com/cmu-delphi/www-covidcast/releases/v3.2.12)