### PR TITLE
update to EPIVis v2.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uikit": "^3.21.13",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.9/www-epivis-2.1.9.tgz"
+        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.10/www-epivis-2.1.10.tgz"
       },
       "devDependencies": {
         "hugo-bin": "^0.127.0",
@@ -2652,9 +2652,9 @@
       }
     },
     "node_modules/www-epivis": {
-      "version": "2.1.9",
-      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.9/www-epivis-2.1.9.tgz",
-      "integrity": "sha512-Wm6bvnTgMFljEY5eeOb6IVHIi/6tVHh2hpOvmCNXMqFwpb7a+avU4nypvu4muG4exBtQjGgu/ACzZ9t0Ir2f8Q==",
+      "version": "2.1.10",
+      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.10/www-epivis-2.1.10.tgz",
+      "integrity": "sha512-wrW3Xx0C5ker5jHbJhLZEepYN263OfTb2XXCoSJWhuaTepa6EcGVrs6q0PLranf5cnD4cEV2K8Zt++64pb96sg==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.15.5"
@@ -4480,8 +4480,8 @@
       }
     },
     "www-epivis": {
-      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.9/www-epivis-2.1.9.tgz",
-      "integrity": "sha512-Wm6bvnTgMFljEY5eeOb6IVHIi/6tVHh2hpOvmCNXMqFwpb7a+avU4nypvu4muG4exBtQjGgu/ACzZ9t0Ir2f8Q==",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.10/www-epivis-2.1.10.tgz",
+      "integrity": "sha512-wrW3Xx0C5ker5jHbJhLZEepYN263OfTb2XXCoSJWhuaTepa6EcGVrs6q0PLranf5cnD4cEV2K8Zt++64pb96sg==",
       "requires": {
         "uikit": "^3.15.5"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uikit": "^3.21.13",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.9/www-epivis-2.1.9.tgz"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.10/www-epivis-2.1.10.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.127.0",


### PR DESCRIPTION
update to [EPIVis v2.1.10](https://github.com/cmu-delphi/www-epivis/releases/v2.1.10)