### PR TITLE
doc: update epidatr and epidatpy info

### DIFF
--- a/content/code/_index.md
+++ b/content/code/_index.md
@@ -16,12 +16,12 @@ The core server code for the [Delphi Epidata API](https://cmu-delphi.github.io/d
 ### [Epidatr](https://cmu-delphi.github.io/epidatr/)
 
 R client for the [Delphi Epidata API](https://cmu-delphi.github.io/delphi-epidata/).
-It allows you to cache queries locally to speed up data access and seamlessly integrate pulling from our API into your pipelines.
+Download data from our API as a usable tibble in R!
 
-### [Epidatpy](https://github.com/cmu-delphi/epidatpy) (WIP)
+### [Epidatpy](https://github.com/cmu-delphi/epidatpy)
 
-A work-in-progress Python client for the [Delphi Epidata API](https://cmu-delphi.github.io/delphi-epidata/).
-Not yet recommended for production, but we are happy to receive feedback!
+Python client for the [Delphi Epidata API](https://cmu-delphi.github.io/delphi-epidata/).
+Download data from our API as a usable Pandas dataframe in Python!
 
 ## Forecasting
 


### PR DESCRIPTION
Saw some out of date bits on this page while making a QR code link to it on the tooling poster. 

Small updates to the client language:
- take WIP tag out of epidatpy
- improve the blurb about each client