### PR TITLE
update to EPIVis v2.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uikit": "^3.21.13",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.10/www-epivis-2.1.10.tgz"
+        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.11/www-epivis-2.1.11.tgz"
       },
       "devDependencies": {
         "hugo-bin": "^0.142.0",
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/www-epivis": {
-      "version": "2.1.10",
-      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.10/www-epivis-2.1.10.tgz",
-      "integrity": "sha512-wrW3Xx0C5ker5jHbJhLZEepYN263OfTb2XXCoSJWhuaTepa6EcGVrs6q0PLranf5cnD4cEV2K8Zt++64pb96sg==",
+      "version": "2.1.11",
+      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.11/www-epivis-2.1.11.tgz",
+      "integrity": "sha512-PI95VMVCCmeykauAyKxu6OAa/2boUQydw4aMU5RXA3mBRCIZ2EcFlPxJqeAh2qV0vNFpJZOvC79qUvYER/MrJA==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.15.5"
@@ -4483,8 +4483,8 @@
       }
     },
     "www-epivis": {
-      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.10/www-epivis-2.1.10.tgz",
-      "integrity": "sha512-wrW3Xx0C5ker5jHbJhLZEepYN263OfTb2XXCoSJWhuaTepa6EcGVrs6q0PLranf5cnD4cEV2K8Zt++64pb96sg==",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.11/www-epivis-2.1.11.tgz",
+      "integrity": "sha512-PI95VMVCCmeykauAyKxu6OAa/2boUQydw4aMU5RXA3mBRCIZ2EcFlPxJqeAh2qV0vNFpJZOvC79qUvYER/MrJA==",
       "requires": {
         "uikit": "^3.15.5"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uikit": "^3.21.13",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.10/www-epivis-2.1.10.tgz"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.11/www-epivis-2.1.11.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.142.0",


### PR DESCRIPTION
update to [EPIVis v2.1.11](https://github.com/cmu-delphi/www-epivis/releases/v2.1.11)