### PR TITLE
update to COVIDcast v3.2.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "highlight.js": "^11.11.1",
         "katex": "^0.16.21",
         "uikit": "^3.21.13",
-        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
+        "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.13/www-covidcast-3.2.13.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
         "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.11/www-epivis-2.1.11.tgz"
       },
@@ -2638,9 +2638,9 @@
       "dev": true
     },
     "node_modules/www-covidcast": {
-      "version": "3.2.12",
-      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
-      "integrity": "sha512-lkQQ+ZIxpipied3zkHV4MTdDIaEljUjY9ObmmgtfKQjTTTQKinGhdrq6belVEwxKLF2p7x03A7T8vfmyPoMYbw==",
+      "version": "3.2.13",
+      "resolved": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.13/www-covidcast-3.2.13.tgz",
+      "integrity": "sha512-akkbRBTynJqI4Uvd/Jk7O7b51v7d9qBRFLsymzyq0M+9ywyAQyHcVOruSUUd6Z+txlbn5bwPRO5mUakTeVxTgA==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.16.13"
@@ -4469,8 +4469,8 @@
       "dev": true
     },
     "www-covidcast": {
-      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
-      "integrity": "sha512-lkQQ+ZIxpipied3zkHV4MTdDIaEljUjY9ObmmgtfKQjTTTQKinGhdrq6belVEwxKLF2p7x03A7T8vfmyPoMYbw==",
+      "version": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.13/www-covidcast-3.2.13.tgz",
+      "integrity": "sha512-akkbRBTynJqI4Uvd/Jk7O7b51v7d9qBRFLsymzyq0M+9ywyAQyHcVOruSUUd6Z+txlbn5bwPRO5mUakTeVxTgA==",
       "requires": {
         "uikit": "^3.16.13"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight.js": "^11.11.1",
     "katex": "^0.16.21",
     "uikit": "^3.21.13",
-    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.12/www-covidcast-3.2.12.tgz",
+    "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.13/www-covidcast-3.2.13.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
     "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.11/www-epivis-2.1.11.tgz"
   },


### PR DESCRIPTION
update to [COVIDcast v3.2.13](https://github.com/cmu-delphi/www-covidcast/releases/v3.2.13)

(just dependency updates)