### PR TITLE
make lint:prettier step in ci output useful info

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "start": "hugo server -D",
     "start:blog": "Rscript -e \"blogdown::serve_site(port=1313, browser=FALSE)\"",
     "format": "prettier *.* \"(.vscode|content|data|themes)/**\" --write",
-    "lint": "prettier *.* \"(.vscode|content|data|themes)/**\" --check",
+    "lint": "prettier *.* \"(.vscode|content|data|themes)/**\" --check || (prettier *.* \"(.vscode|content|data|themes)/**\" --write ; git diff ; false)",
     "image": "docker build -t www-main:latest --file ./devops/Dockerfile .",
     "prepare": "husky install",
     "prepack": "npm run build"


### PR DESCRIPTION
The "ci" gh action had [a failure](https://github.com/cmu-delphi/www-main/actions/runs/15593248957/job/43917338400) in [the lint step](https://github.com/cmu-delphi/www-main/blob/034619468825a99cfb06c7c5b39c971b505b577f/.github/workflows/ci.yaml#L25) after [a recent PR](https://github.com/cmu-delphi/www-main/pull/1074) (which failed the "`prettier`" check) was merged.

The failure was not noticed before merge because the check was not even run, as the PR was based on a forked branch instead of the typical branch inside this repo.

(this change is very much like the one in https://github.com/cmu-delphi/www-epivis/pull/109/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27 )