### PR TITLE
update to EPIVis v2.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uikit": "^3.21.13",
         "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.14/www-covidcast-3.2.14.tgz",
         "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.13/www-epivis-2.1.13.tgz"
+        "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.14/www-epivis-2.1.14.tgz"
       },
       "devDependencies": {
         "hugo-bin": "^0.142.0",
@@ -2425,9 +2425,9 @@
       }
     },
     "node_modules/www-epivis": {
-      "version": "2.1.13",
-      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.13/www-epivis-2.1.13.tgz",
-      "integrity": "sha512-/6iHu15CaFwmQ7NCGnYXkhjv+6qAfGKiZ42OiEvjp1l6gSCDeQokUJU2S3trP+qOGq2W7h4vPKpt+VNUH2XI0w==",
+      "version": "2.1.14",
+      "resolved": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.14/www-epivis-2.1.14.tgz",
+      "integrity": "sha512-Md0TnnZDx9glqi/0NYhVrNhbYkQkcIaY4pwXZ+orkqw45MepdIF/G1gRymBRwFoW2eZm4/MMhI81HHTogrsjmQ==",
       "license": "MIT",
       "dependencies": {
         "uikit": "^3.15.5"
@@ -4075,8 +4075,8 @@
       }
     },
     "www-epivis": {
-      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.13/www-epivis-2.1.13.tgz",
-      "integrity": "sha512-/6iHu15CaFwmQ7NCGnYXkhjv+6qAfGKiZ42OiEvjp1l6gSCDeQokUJU2S3trP+qOGq2W7h4vPKpt+VNUH2XI0w==",
+      "version": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.14/www-epivis-2.1.14.tgz",
+      "integrity": "sha512-Md0TnnZDx9glqi/0NYhVrNhbYkQkcIaY4pwXZ+orkqw45MepdIF/G1gRymBRwFoW2eZm4/MMhI81HHTogrsjmQ==",
       "requires": {
         "uikit": "^3.15.5"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uikit": "^3.21.13",
     "www-covidcast": "https://github.com/cmu-delphi/www-covidcast/releases/download/v3.2.14/www-covidcast-3.2.14.tgz",
     "www-covidcast-classic": "https://github.com/cmu-delphi/www-covidcast-classic/releases/download/v2.6.7/www-covidcast-classic-2.6.7.tgz",
-    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.13/www-epivis-2.1.13.tgz"
+    "www-epivis": "https://github.com/cmu-delphi/www-epivis/releases/download/v2.1.14/www-epivis-2.1.14.tgz"
   },
   "devDependencies": {
     "hugo-bin": "^0.142.0",


### PR DESCRIPTION
update to [EPIVis v2.1.14](https://github.com/cmu-delphi/www-epivis/releases/v2.1.14)